### PR TITLE
fix missing default entities/classes/properties in the APIs

### DIFF
--- a/sand/config.py
+++ b/sand/config.py
@@ -1,5 +1,4 @@
 import os
-
 from pathlib import Path
 
 _ROOT_DIR = Path(os.path.abspath(__file__)).parent.parent
@@ -11,8 +10,8 @@ CACHE_SIZE = 10240
 SETTINGS = {
     "entity": {
         "constructor": "sand.extensions.wikidata.get_entity_db",
-        "uri2id": "sm.namespaces.prelude.WikidataNamespace.get_entity_id",
-        "id2uri": "sm.namespaces.prelude.WikidataNamespace.get_entity_abs_uri",
+        "uri2id": "sand.extensions.wikidata.uri2id",
+        "id2uri": "sand.extensions.wikidata.id2uri",
         "args": {
             "dbfile": "/tmp/wdentities.db",
             "proxy": True,
@@ -24,14 +23,14 @@ SETTINGS = {
             "http://www.wikidata.org": "P31",
         },
         # id of an nil entity
-        "nil": "drepr:nil",
+        "nil": {"id": "drepr:nil", "uri": "https://purl.org/drepr/ontology/1.0/nil"},
         # template for new entity uri
         "new_entity_template": "http://www.wikidata.org/entity/{id}",
     },
     "ont_classes": {
         "constructor": "sand.extensions.wikidata.get_ontclass_db",
         "uri2id": "sand.extensions.wikidata.uri2id",
-        "id2uri": "sm.namespaces.prelude.WikidataNamespace.get_entity_abs_uri",
+        "id2uri": "sand.extensions.wikidata.id2uri",
         "args": {
             "dbfile": "/tmp/wdclasses.db",
             "proxy": True,
@@ -42,7 +41,7 @@ SETTINGS = {
     "ont_props": {
         "constructor": "sand.extensions.wikidata.get_ontprop_db",
         "uri2id": "sand.extensions.wikidata.uri2id",
-        "id2uri": "sm.namespaces.prelude.WikidataNamespace.get_prop_abs_uri",
+        "id2uri": "sand.extensions.wikidata.id2uri",
         "args": {
             "dbfile": "/tmp/wdprops.db",
             "proxy": True,
@@ -67,10 +66,10 @@ SETTINGS = {
     "search": {
         "entities": "sand.extensions.search.wikidata_search.WikidataSearch",
         "classes": "sand.extensions.search.wikidata_search.WikidataSearch",
-        "props": "sand.extensions.search.wikidata_search.WikidataSearch"
+        "props": "sand.extensions.search.wikidata_search.WikidataSearch",
     },
     "exports": {
         "drepr": "sand.extensions.export.drepr.main.DreprExport",
-        "default": "sand.extensions.export.drepr.main.DreprExport"
-    }
+        "default": "sand.extensions.export.drepr.main.DreprExport",
+    },
 }

--- a/sand/controllers/assistant.py
+++ b/sand/controllers/assistant.py
@@ -13,7 +13,7 @@ from werkzeug.exceptions import BadRequest, NotFound
 from sand.config import SETTINGS
 from sand.extension_interface.assistant import IAssistant
 from sand.helpers.tree_utils import TreeStruct
-from sand.models.entity import NIL_ENTITY, Entity, EntityAR
+from sand.models.entity import NIL_ENTITY_ID, Entity, EntityAR
 from sand.models.ontology import OntClass, OntClassAR, OntPropertyAR
 from sand.models.table import Link, Table, TableRow
 from sand.serializer import get_label, serialize_graph
@@ -120,7 +120,7 @@ def gather_column_types():
         for link in row.links.get(column, []):
             if (
                 link.entity_id is not None
-                and link.entity_id != NIL_ENTITY
+                and link.entity_id != NIL_ENTITY_ID
                 and link.entity_id not in ents
             ):
                 ents[link.entity_id] = entities.get(link.entity_id, None)

--- a/sand/extensions/export/drepr/resources.py
+++ b/sand/extensions/export/drepr/resources.py
@@ -1,16 +1,16 @@
+import csv
 from dataclasses import dataclass
 from io import StringIO
-import orjson, csv
 from typing import Dict, List, Set, Tuple
+from uuid import uuid4
+
+import orjson
+from drepr.models import ResourceData, ResourceDataString
+
 from sand.config import SETTINGS
-from sand.models.entity import NIL_ENTITY, Entity
+from sand.models.entity import NIL_ENTITY_ID, Entity
 from sand.models.ontology import OntPropertyAR
 from sand.models.table import Table, TableRow
-from drepr.models import (
-    ResourceDataString,
-    ResourceData,
-)
-from uuid import uuid4
 
 
 def get_table_resource(table: Table, rows: List[TableRow]) -> ResourceData:
@@ -46,7 +46,7 @@ def get_entity_resource(
             # for now, just return the first entity
             ent = None
             for link in links:
-                if link.entity_id is not None and link.entity_id != NIL_ENTITY:
+                if link.entity_id is not None and link.entity_id != NIL_ENTITY_ID:
                     ent = Entity.id2uri(link.entity_id)
                     break
             else:

--- a/sand/extensions/export/drepr/semanticmodel.py
+++ b/sand/extensions/export/drepr/semanticmodel.py
@@ -1,16 +1,18 @@
+import csv
 from dataclasses import dataclass
 from io import StringIO
-import orjson, csv
 from typing import Callable, Dict, List, Mapping, Set, Tuple
+
+import drepr.models.sm as drepr_sm
+import orjson
+import sm.misc as M
+import sm.outputs.semantic_model as O
+from sm.namespaces.wikidata import WikidataNamespace
+
 from sand.config import SETTINGS
-from sand.models.entity import NIL_ENTITY, Entity
+from sand.models.entity import NIL_ENTITY_ID, Entity
 from sand.models.ontology import OntProperty, OntPropertyAR, OntPropertyDataType
 from sand.models.table import Table, TableRow
-import sm.outputs.semantic_model as O
-import sm.misc as M
-from sm.namespaces.wikidata import WikidataNamespace
-import drepr.models.sm as drepr_sm
-
 
 prefixes = WikidataNamespace.create().prefix2ns.copy()
 prefixes.update(drepr_sm.SemanticModel.get_default_prefixes())

--- a/sand/models/ontology.py
+++ b/sand/models/ontology.py
@@ -1,8 +1,10 @@
 from dataclasses import dataclass, field
 from typing import Dict, List, Literal, Mapping, Set
 
+from hugedict.chained_mapping import ChainedMapping
 from rdflib import RDFS
-from sm.misc.funcs import import_func
+from sm.misc.funcs import import_attr, import_func
+
 from sand.config import SETTINGS
 
 
@@ -34,6 +36,7 @@ class OntClass:
             "The method is set when its store is initialized. Check the call order to ensure `OntClassAR` is called first"
         )
 
+
 OntPropertyDataType = Literal[
     "monolingualtext",
     "url",
@@ -42,7 +45,7 @@ OntPropertyDataType = Literal[
     "number",
     "string",
     "globe-coordinate",
-    "unknown"  # don't know the type yet
+    "unknown",  # don't know the type yet
 ]
 
 
@@ -75,6 +78,7 @@ class OntProperty:
             "The method is set when its store is initialized. Check the call order to ensure `OntPropertyAR` is called first"
         )
 
+
 PROP_AR = None
 CLASS_AR = None
 
@@ -99,7 +103,7 @@ def OntPropertyAR() -> Mapping[str, OntProperty]:
     if PROP_AR is None:
         cfg = SETTINGS["ont_props"]
         func = import_func(cfg["constructor"])
-        PROP_AR = func(**cfg["args"])
+        PROP_AR = ChainedMapping(func(**cfg["args"]), import_attr(cfg["default"]))
         OntProperty.uri2id = import_func(cfg["uri2id"])
         OntProperty.id2uri = import_func(cfg["id2uri"])
 
@@ -113,7 +117,7 @@ def OntClassAR() -> Mapping[str, OntClass]:
     if CLASS_AR is None:
         cfg = SETTINGS["ont_classes"]
         func = import_func(cfg["constructor"])
-        CLASS_AR = func(**cfg["args"])
+        CLASS_AR = ChainedMapping(func(**cfg["args"]), import_attr(cfg["default"]))
         OntClass.uri2id = import_func(cfg["uri2id"])
         OntClass.id2uri = import_func(cfg["id2uri"])
     return CLASS_AR

--- a/sand/serializer.py
+++ b/sand/serializer.py
@@ -2,12 +2,12 @@ from dataclasses import asdict
 from functools import partial
 from typing import Callable, Dict, List, Mapping, Optional
 
+import sm.outputs.semantic_model as O
 from playhouse.shortcuts import model_to_dict
 
-import sm.outputs.semantic_model as O
 from sand.models import SemanticModel, Table
 from sand.models.entity import Entity, EntityAR
-from sand.models.ontology import OntProperty, OntClass, OntPropertyAR, OntClassAR
+from sand.models.ontology import OntClass, OntClassAR, OntProperty, OntPropertyAR
 
 
 def serialize_property(prop: OntProperty):
@@ -40,7 +40,7 @@ def serialize_class(cls: OntClass):
 def serialize_entity(ent: Entity):
     return {
         "id": ent.id,
-        "uri": Entity.id2uri(ent.id),
+        "uri": ent.uri,
         "readable_label": ent.readable_label,
         "label": ent.label.to_dict(),
         "aliases": ent.aliases.to_dict(),

--- a/www/package.json
+++ b/www/package.json
@@ -69,10 +69,13 @@
     "rules": {
       "jsx-a11y/anchor-is-valid": "off",
       "react-hooks/exhaustive-deps": "off",
-      "@typescript-eslint/no-unused-vars": ["warn", {
-        "args": "none",
-        "varsIgnorePattern": "^_"
-      }]
+      "@typescript-eslint/no-unused-vars": [
+        "warn",
+        {
+          "args": "none",
+          "varsIgnorePattern": "^_"
+        }
+      ]
     }
   },
   "proxy": "http://127.0.0.1:5525",

--- a/www/src/models/AssistantService.ts
+++ b/www/src/models/AssistantService.ts
@@ -112,7 +112,7 @@ export class AssistantService extends RStore<number, AssistantRecord> {
       for (const link of row.links[columnIndex] || []) {
         if (
           link.entityId !== undefined &&
-          link.entityId !== appConfig.NIL_ENTITY
+          link.entityId !== appConfig.NIL_ENTITY_ID
         ) {
           entIds.add(link.entityId);
         }
@@ -190,7 +190,7 @@ export class AssistantService extends RStore<number, AssistantRecord> {
       for (const link of row.links[columnIndex] || []) {
         if (
           link.entityId !== undefined &&
-          link.entityId !== appConfig.NIL_ENTITY
+          link.entityId !== appConfig.NIL_ENTITY_ID
         ) {
           entIds.add(link.entityId);
         }

--- a/www/src/models/settings/ApplicationConfig.ts
+++ b/www/src/models/settings/ApplicationConfig.ts
@@ -86,7 +86,7 @@ export class StartsWithIndex<V> {
 
 export class ApplicationConfig {
   // configuration related to entities
-  public NIL_ENTITY: string = "";
+  public NIL_ENTITY_ID: string = "";
 
   // list of properties' uris that when a column is tagged with one of them, the column is an entity column
   public SEM_MODEL_IDENTS = new Set<string>();

--- a/www/src/models/settings/index.ts
+++ b/www/src/models/settings/index.ts
@@ -25,7 +25,7 @@ export class UISettings {
   async fetchSettings() {
     const resp = await axios.get("/api/settings");
     appConfig.setInstanceOf(resp.data["entity"]["instanceof"]);
-    appConfig.NIL_ENTITY = resp.data["entity"]["nil"];
+    appConfig.NIL_ENTITY_ID = resp.data["entity"]["nil"]["id"];
     appConfig.SEM_MODEL_IDENTS = new Set(
       resp.data["semantic_model"]["identifiers"]
     );

--- a/www/src/pages/table/table/CandidateEntityListComponent.tsx
+++ b/www/src/pages/table/table/CandidateEntityListComponent.tsx
@@ -193,7 +193,7 @@ export const CandidateEntityListComponent = withStyles(styles)(
 
       // nil entity & create new entity
       const className =
-        links.length > 0 && links[0].entityId === appConfig.NIL_ENTITY
+        links.length > 0 && links[0].entityId === appConfig.NIL_ENTITY_ID
           ? classes.correctCandidateEntity
           : classes.candidateEntity;
 
@@ -203,19 +203,21 @@ export const CandidateEntityListComponent = withStyles(styles)(
             <CheckboxIcon
               icon={faCheck}
               selected={
-                links.length > 0 && links[0].entityId === appConfig.NIL_ENTITY
+                links.length > 0 &&
+                links[0].entityId === appConfig.NIL_ENTITY_ID
               }
-              onChange={singleUpdate(appConfig.NIL_ENTITY)}
+              onChange={singleUpdate(appConfig.NIL_ENTITY_ID)}
             />
             <CheckboxIcon
               icon={faCheckDouble}
               selected={
-                links.length > 0 && links[0].entityId === appConfig.NIL_ENTITY
+                links.length > 0 &&
+                links[0].entityId === appConfig.NIL_ENTITY_ID
               }
-              onChange={selectMultiple(appConfig.NIL_ENTITY)}
+              onChange={selectMultiple(appConfig.NIL_ENTITY_ID)}
             />
             <FetchEntityComponent
-              entityId={appConfig.NIL_ENTITY}
+              entityId={appConfig.NIL_ENTITY_ID}
               render={(entity, settings) => (
                 <PopoverEntityComponent entity={entity} settings={settings}>
                   <InlineEntityComponent

--- a/www/src/pages/table/table/CellComponent.tsx
+++ b/www/src/pages/table/table/CellComponent.tsx
@@ -70,7 +70,7 @@ export const CellComponent = withStyles(styles)(
               className={
                 classes.link +
                 (link.entityId === undefined ||
-                link.entityId === appConfig.NIL_ENTITY
+                link.entityId === appConfig.NIL_ENTITY_ID
                   ? " " + classes.noEntityLink
                   : "")
               }

--- a/www/src/pages/table/table/filters/Filter.ts
+++ b/www/src/pages/table/table/filters/Filter.ts
@@ -129,7 +129,7 @@ export class ColumnFilter {
       if (this.selectNil || this.selectUnlinked) {
         for (const link of row.links[this.columnIndex] || []) {
           if (
-            (this.selectNil && link.entityId === appConfig.NIL_ENTITY) ||
+            (this.selectNil && link.entityId === appConfig.NIL_ENTITY_ID) ||
             (this.selectUnlinked && link.entityId === undefined)
           )
             return true;
@@ -149,7 +149,7 @@ export class ColumnFilter {
       const entIds = new Set<string>();
       for (const link of row.links[this.columnIndex] || []) {
         if (
-          link.entityId !== appConfig.NIL_ENTITY &&
+          link.entityId !== appConfig.NIL_ENTITY_ID &&
           link.entityId !== undefined
         ) {
           entIds.add(link.entityId);

--- a/www/yarn.lock
+++ b/www/yarn.lock
@@ -3966,9 +3966,9 @@ caniuse-api@^3.0.0:
     lodash.uniq "^4.5.0"
 
 caniuse-lite@^1.0.0, caniuse-lite@^1.0.30000981, caniuse-lite@^1.0.30001109, caniuse-lite@^1.0.30001125, caniuse-lite@^1.0.30001313:
-  version "1.0.30001315"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001315.tgz#f1b1efd1171ee1170d52709a7252632dacbd7c77"
-  integrity sha512-5v7LFQU4Sb/qvkz7JcZkvtSH1Ko+1x2kgo3ocdBeMGZSOFpuE1kkm0kpTwLtWeFrw5qw08ulLxJjVIXIS8MkiQ==
+  version "1.0.30001504"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001504.tgz"
+  integrity sha512-5uo7eoOp2mKbWyfMXnGO9rJWOGU8duvzEiYITW+wivukL7yHH4gX9yuRaobu6El4jPxo6jKZfG+N6fB621GD/Q==
 
 capture-exit@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Recent changes in the server removed default entities/classes/properties. Consequentially, accessing to `drepr:nil` returns 404. This PR fixes this problem.