### PR TITLE
 Enabled Local search for default classes, entities and properties

### DIFF
--- a/sand/config.py
+++ b/sand/config.py
@@ -64,9 +64,9 @@ SETTINGS = {
         # "default": "mtab",
     },
     "search": {
-        "entities": "sand.extensions.search.aggregated_search.AggregatedSearch",
-        "classes": "sand.extensions.search.aggregated_search.AggregatedSearch",
-        "props": "sand.extensions.search.aggregated_search.AggregatedSearch",
+        "entities": "sand.extensions.search.wikidata_search.WikidataSearch",
+        "classes": "sand.extensions.search.wikidata_search.WikidataSearch",
+        "props": "sand.extensions.search.wikidata_search.WikidataSearch",
     },
     "exports": {
         "drepr": "sand.extensions.export.drepr.main.DreprExport",

--- a/sand/config.py
+++ b/sand/config.py
@@ -64,9 +64,9 @@ SETTINGS = {
         # "default": "mtab",
     },
     "search": {
-        "entities": "sand.extensions.search.wikidata_search.WikidataSearch",
-        "classes": "sand.extensions.search.wikidata_search.WikidataSearch",
-        "props": "sand.extensions.search.wikidata_search.WikidataSearch",
+        "entities": "sand.extensions.search.wikidata_search.extended_wikidata_search",
+        "classes": "sand.extensions.search.wikidata_search.extended_wikidata_search",
+        "props": "sand.extensions.search.wikidata_search.extended_wikidata_search",
     },
     "exports": {
         "drepr": "sand.extensions.export.drepr.main.DreprExport",

--- a/sand/config.py
+++ b/sand/config.py
@@ -64,9 +64,9 @@ SETTINGS = {
         # "default": "mtab",
     },
     "search": {
-        "entities": "sand.extensions.search.wikidata_search.WikidataSearch",
-        "classes": "sand.extensions.search.wikidata_search.WikidataSearch",
-        "props": "sand.extensions.search.wikidata_search.WikidataSearch",
+        "entities": "sand.extensions.search.aggregated_search.AggregatedSearch",
+        "classes": "sand.extensions.search.aggregated_search.AggregatedSearch",
+        "props": "sand.extensions.search.aggregated_search.AggregatedSearch",
     },
     "exports": {
         "drepr": "sand.extensions.export.drepr.main.DreprExport",

--- a/sand/controllers/search.py
+++ b/sand/controllers/search.py
@@ -26,7 +26,7 @@ def get_search(name: Literal['classes', 'entities', 'props']) -> Union[IEntitySe
         GetSearchCache.search = {}
         search_config = SETTINGS["search"]
         constructor = search_config[name]
-        GetSearchCache.search[name] = import_func(constructor)()
+        GetSearchCache.search[name] = import_func(constructor)().extended_wikidata_search()
 
     return GetSearchCache.search[name]
 

--- a/sand/controllers/search.py
+++ b/sand/controllers/search.py
@@ -26,7 +26,7 @@ def get_search(name: Literal['classes', 'entities', 'props']) -> Union[IEntitySe
         GetSearchCache.search = {}
         search_config = SETTINGS["search"]
         constructor = search_config[name]
-        GetSearchCache.search[name] = import_func(constructor)().extended_wikidata_search()
+        GetSearchCache.search[name] = import_func(constructor)()
 
     return GetSearchCache.search[name]
 

--- a/sand/extensions/search/aggregated_search.py
+++ b/sand/extensions/search/aggregated_search.py
@@ -11,8 +11,10 @@ class AggregatedSearch(IEntitySearch, IOntologySearch):
 
     def add(self, search_obj: Union[IEntitySearch, IOntologySearch]):
         """adds a search object to the aggregated search"""
-        self.search_entity_objs.append(search_obj)
-        self.search_ontology_objs.append(search_obj)
+        if isinstance(search_obj, IEntitySearch):
+            self.search_entity_objs.append(search_obj)
+        if isinstance(search_obj, IOntologySearch):
+            self.search_ontology_objs.append(search_obj)
 
     def find_class_by_name(self, search_text: str) -> List[SearchResult]:
         """Performs generic class search based on name"""

--- a/sand/extensions/search/aggregated_search.py
+++ b/sand/extensions/search/aggregated_search.py
@@ -1,0 +1,43 @@
+from typing import List, Union
+from sand.extension_interface.search import IEntitySearch, IOntologySearch
+from sand.models.search import SearchResult
+from sand.extensions.search.default_search import DefaultSearch
+from sand.extensions.search.wikidata_search import WikidataSearch
+
+
+class AggregatedSearch(IEntitySearch, IOntologySearch):
+
+    def __init__(self):
+        self.search_objs = []
+
+    def add(self, search_obj: Union[IEntitySearch, IOntologySearch]):
+        """adds a search object to the aggregated search"""
+        self.search_objs.append(search_obj)
+
+    def extended_wikidata_search(self) -> Union[IEntitySearch,IOntologySearch]:
+        """extended version of wikidata search by aggregating default search"""
+        search = AggregatedSearch()
+        search.add(DefaultSearch())
+        search.add(WikidataSearch())
+        return search
+
+    def find_class_by_name(self, search_text: str) -> List[SearchResult]:
+        """Performs generic class search based on name"""
+        payload_results = []
+        for search_obj in self.search_objs:
+            payload_results += search_obj.find_class_by_name(search_text)
+        return payload_results
+
+    def find_entity_by_name(self, search_text: str) -> List[SearchResult]:
+        """Performs generic entity search based on name"""
+        payload_results = []
+        for search_obj in self.search_objs:
+            payload_results += search_obj.find_entity_by_name(search_text)
+        return payload_results
+
+    def find_props_by_name(self, search_text: str) -> List[SearchResult]:
+        """Performs generic property search based on name"""
+        payload_results = []
+        for search_obj in self.search_objs:
+            payload_results += search_obj.find_props_by_name(search_text)
+        return payload_results

--- a/sand/extensions/search/aggregated_search.py
+++ b/sand/extensions/search/aggregated_search.py
@@ -1,8 +1,6 @@
 from typing import List, Union
 from sand.extension_interface.search import IEntitySearch, IOntologySearch
 from sand.models.search import SearchResult
-from sand.extensions.search.default_search import DefaultSearch
-from sand.extensions.search.wikidata_search import WikidataSearch
 
 
 class AggregatedSearch(IEntitySearch, IOntologySearch):
@@ -13,13 +11,6 @@ class AggregatedSearch(IEntitySearch, IOntologySearch):
     def add(self, search_obj: Union[IEntitySearch, IOntologySearch]):
         """adds a search object to the aggregated search"""
         self.search_objs.append(search_obj)
-
-    def extended_wikidata_search(self) -> Union[IEntitySearch,IOntologySearch]:
-        """extended version of wikidata search by aggregating default search"""
-        search = AggregatedSearch()
-        search.add(DefaultSearch())
-        search.add(WikidataSearch())
-        return search
 
     def find_class_by_name(self, search_text: str) -> List[SearchResult]:
         """Performs generic class search based on name"""

--- a/sand/extensions/search/aggregated_search.py
+++ b/sand/extensions/search/aggregated_search.py
@@ -6,29 +6,31 @@ from sand.models.search import SearchResult
 class AggregatedSearch(IEntitySearch, IOntologySearch):
 
     def __init__(self):
-        self.search_objs = []
+        self.search_entity_objs = []
+        self.search_ontology_objs = []
 
     def add(self, search_obj: Union[IEntitySearch, IOntologySearch]):
         """adds a search object to the aggregated search"""
-        self.search_objs.append(search_obj)
+        self.search_entity_objs.append(search_obj)
+        self.search_ontology_objs.append(search_obj)
 
     def find_class_by_name(self, search_text: str) -> List[SearchResult]:
         """Performs generic class search based on name"""
         payload_results = []
-        for search_obj in self.search_objs:
+        for search_obj in self.search_ontology_objs:
             payload_results += search_obj.find_class_by_name(search_text)
         return payload_results
 
     def find_entity_by_name(self, search_text: str) -> List[SearchResult]:
         """Performs generic entity search based on name"""
         payload_results = []
-        for search_obj in self.search_objs:
+        for search_obj in self.search_entity_objs:
             payload_results += search_obj.find_entity_by_name(search_text)
         return payload_results
 
     def find_props_by_name(self, search_text: str) -> List[SearchResult]:
         """Performs generic property search based on name"""
         payload_results = []
-        for search_obj in self.search_objs:
+        for search_obj in self.search_ontology_objs:
             payload_results += search_obj.find_props_by_name(search_text)
         return payload_results

--- a/sand/extensions/search/default_search.py
+++ b/sand/extensions/search/default_search.py
@@ -17,7 +17,7 @@ class DefaultSearch(IEntitySearch, IOntologySearch):
         """ performs local partial text search across default entities"""
         query_tokens = re.findall(r'[a-z]+|\d+', search_text.lower())
         search_results = []
-        for key, entity in default_entities.items():
+        for entity in default_entities.values():
             label = entity.label.lower()
             if all(token in label for token in query_tokens):
                 search_results.append(entity)

--- a/sand/extensions/search/default_search.py
+++ b/sand/extensions/search/default_search.py
@@ -15,7 +15,7 @@ class DefaultSearch(IEntitySearch, IOntologySearch):
 
     def local_search(self, default_entities: dict, search_text: str) -> List:
         """ performs local partial text search across default entities"""
-        query_tokens = re.findall(r'[a-z]+|\d+', search_text.lower())
+        query_tokens = re.findall(r'[a-z]+', search_text.lower())
         search_results = []
         for entity in default_entities.values():
             label = entity.label.lower()

--- a/sand/extensions/search/default_search.py
+++ b/sand/extensions/search/default_search.py
@@ -8,20 +8,24 @@ from sand.config import SETTINGS
 
 class DefaultSearch(IEntitySearch, IOntologySearch):
 
+    def __init__(self):
+        self.default_classes = import_attr(SETTINGS['ont_classes']['default'])
+        self.default_entities = import_attr(SETTINGS['entity']['default'])
+        self.default_properties = import_attr(SETTINGS['ont_props']['default'])
+
     def local_search(self, default_entities: dict, search_text: str) -> List:
         """ performs local partial text search across default entities"""
         query_tokens = re.findall("[a-zA-Z]+", search_text)
         search_results = []
         for key, entity in default_entities.items():
-            if all(list(map(lambda x: x.lower() in entity.label.lower(), query_tokens))):
+            label = entity.label.lower()
+            if all(list(map(lambda x: x.lower() in label, query_tokens))):
                 search_results.append(entity)
         return search_results
 
     def find_class_by_name(self, search_text: str) -> List[SearchResult]:
         """Uses local default classes to search for entities using their name/text."""
-        constructor = SETTINGS['ont_classes']['default']
-        default_classes = import_attr(constructor)
-        local_search_results = self.local_search(default_classes, search_text)
+        local_search_results = self.local_search(self.default_classes, search_text)
         payload_results = []
 
         for entity in local_search_results:
@@ -37,9 +41,7 @@ class DefaultSearch(IEntitySearch, IOntologySearch):
 
     def find_entity_by_name(self, search_text: str) -> List[SearchResult]:
         """Uses local default entities to search for entities using their name/text."""
-        constructor = SETTINGS['entity']['default']
-        default_entities = import_attr(constructor)
-        local_search_results = self.local_search(default_entities, search_text)
+        local_search_results = self.local_search(self.default_entities, search_text)
         payload_results = []
 
         for entity in local_search_results:
@@ -55,10 +57,7 @@ class DefaultSearch(IEntitySearch, IOntologySearch):
 
     def find_props_by_name(self, search_text: str) -> List[SearchResult]:
         """Uses local default properties to search for entities using their name/text."""
-        # search local properties
-        constructor = SETTINGS['ont_props']['default']
-        default_properties = import_attr(constructor)
-        local_search_results = self.local_search(default_properties, search_text)
+        local_search_results = self.local_search(self.default_properties, search_text)
         payload_results = []
 
         for entity in local_search_results:

--- a/sand/extensions/search/default_search.py
+++ b/sand/extensions/search/default_search.py
@@ -1,4 +1,5 @@
 from typing import List
+import re
 from sand.extension_interface.search import IEntitySearch, IOntologySearch
 from sm.misc.funcs import import_attr
 from sand.models.search import SearchResult
@@ -9,7 +10,7 @@ class DefaultSearch(IEntitySearch, IOntologySearch):
 
     def local_search(self, default_entities: dict, search_text: str) -> List:
         """ performs local partial text search across default entities"""
-        query_tokens = search_text.split(" ")
+        query_tokens = re.findall("[a-zA-Z]+", search_text)
         search_results = []
         for key, entity in default_entities.items():
             if all(list(map(lambda x: x.lower() in entity.label.lower(), query_tokens))):

--- a/sand/extensions/search/default_search.py
+++ b/sand/extensions/search/default_search.py
@@ -1,0 +1,72 @@
+from typing import List
+from sand.extension_interface.search import IEntitySearch, IOntologySearch
+from sm.misc.funcs import import_attr
+from sand.models.search import SearchResult
+from sand.config import SETTINGS
+
+
+class DefaultSearch(IEntitySearch, IOntologySearch):
+
+    def local_search(self, default_entities: dict, search_text: str) -> List:
+        """ performs local partial text search across default entities"""
+        query_tokens = search_text.split(" ")
+        search_results = []
+        for key, entity in default_entities.items():
+            if all(list(map(lambda x: x.lower() in entity.label.lower(), query_tokens))):
+                search_results.append(entity)
+        return search_results
+
+    def find_class_by_name(self, search_text: str) -> List[SearchResult]:
+        """Uses local default classes to search for entities using their name/text."""
+        constructor = SETTINGS['ont_classes']['default']
+        default_classes = import_attr(constructor)
+        local_search_results = self.local_search(default_classes, search_text)
+        payload_results = []
+
+        for entity in local_search_results:
+            item = SearchResult(
+                label=entity.label,
+                id=entity.id,
+                description=entity.description,
+                uri=entity.uri
+            )
+            payload_results.append(item)
+
+        return payload_results
+
+    def find_entity_by_name(self, search_text: str) -> List[SearchResult]:
+        """Uses local default entities to search for entities using their name/text."""
+        constructor = SETTINGS['entity']['default']
+        default_entities = import_attr(constructor)
+        local_search_results = self.local_search(default_entities, search_text)
+        payload_results = []
+
+        for entity in local_search_results:
+            item = SearchResult(
+                label=entity.label,
+                id=entity.id,
+                description=entity.description,
+                uri=entity.uri
+            )
+            payload_results.append(item)
+
+        return payload_results
+
+    def find_props_by_name(self, search_text: str) -> List[SearchResult]:
+        """Uses local default properties to search for entities using their name/text."""
+        # search local properties
+        constructor = SETTINGS['ont_props']['default']
+        default_properties = import_attr(constructor)
+        local_search_results = self.local_search(default_properties, search_text)
+        payload_results = []
+
+        for entity in local_search_results:
+            item = SearchResult(
+                label=entity.label,
+                id=entity.id,
+                description=entity.description,
+                uri=entity.uri
+            )
+            payload_results.append(item)
+
+        return payload_results

--- a/sand/extensions/search/default_search.py
+++ b/sand/extensions/search/default_search.py
@@ -15,11 +15,11 @@ class DefaultSearch(IEntitySearch, IOntologySearch):
 
     def local_search(self, default_entities: dict, search_text: str) -> List:
         """ performs local partial text search across default entities"""
-        query_tokens = map(str.lower, re.findall("[a-zA-Z]+", search_text))
+        query_tokens = re.findall(r'[a-z]+|\d+', search_text.lower())
         search_results = []
         for key, entity in default_entities.items():
             label = entity.label.lower()
-            if all(list(map(lambda x: x in label, query_tokens))):
+            if all(token in label for token in query_tokens):
                 search_results.append(entity)
         return search_results
 

--- a/sand/extensions/search/default_search.py
+++ b/sand/extensions/search/default_search.py
@@ -15,11 +15,11 @@ class DefaultSearch(IEntitySearch, IOntologySearch):
 
     def local_search(self, default_entities: dict, search_text: str) -> List:
         """ performs local partial text search across default entities"""
-        query_tokens = re.findall("[a-zA-Z]+", search_text)
+        query_tokens = map(str.lower, re.findall("[a-zA-Z]+", search_text))
         search_results = []
         for key, entity in default_entities.items():
             label = entity.label.lower()
-            if all(list(map(lambda x: x.lower() in label, query_tokens))):
+            if all(list(map(lambda x: x in label, query_tokens))):
                 search_results.append(entity)
         return search_results
 

--- a/sand/extensions/search/default_search.py
+++ b/sand/extensions/search/default_search.py
@@ -15,7 +15,7 @@ class DefaultSearch(IEntitySearch, IOntologySearch):
 
     def local_search(self, default_entities: dict, search_text: str) -> List:
         """ performs local partial text search across default entities"""
-        query_tokens = re.findall(r'[a-z]+', search_text.lower())
+        query_tokens = re.findall(r'[a-z]+|\d+', search_text.lower())
         search_results = []
         for entity in default_entities.values():
             label = entity.label.lower()

--- a/sand/extensions/search/wikidata_search.py
+++ b/sand/extensions/search/wikidata_search.py
@@ -9,6 +9,14 @@ from sand.extensions.search.default_search import DefaultSearch
 from sand.extensions.search.aggregated_search import AggregatedSearch
 
 
+def extended_wikidata_search() -> Union[IEntitySearch, IOntologySearch]:
+    """extended version of wikidata search by aggregating default search"""
+    search = AggregatedSearch()
+    search.add(DefaultSearch())
+    search.add(WikidataSearch())
+    return search
+
+
 class WikidataSearch(IEntitySearch, IOntologySearch):
 
     def __init__(self):
@@ -24,13 +32,6 @@ class WikidataSearch(IEntitySearch, IOntologySearch):
             "srprop": "snippet|titlesnippet"
         }
         self.ont_class_ar = None
-
-    def extended_wikidata_search(self) -> Union[IEntitySearch,IOntologySearch]:
-        """extended version of wikidata search by aggregating default search"""
-        search = AggregatedSearch()
-        search.add(DefaultSearch())
-        search.add(WikidataSearch())
-        return search
 
     def get_class_search_params(self, search_text: str) -> Dict:
         """Updates class search parameters for wikidata API"""

--- a/sand/extensions/search/wikidata_search.py
+++ b/sand/extensions/search/wikidata_search.py
@@ -1,12 +1,10 @@
 import requests
-from typing import Dict, List
+from typing import Dict, List, Union
 import nh3
 from sand.extension_interface.search import IEntitySearch, IOntologySearch
 from sand.models.entity import Entity
 from sand.models.ontology import OntClass, OntProperty, OntClassAR
 from sand.models.search import SearchResult
-from sm.misc.funcs import import_attr
-from sand.config import SETTINGS
 
 
 class WikidataSearch(IEntitySearch, IOntologySearch):
@@ -32,15 +30,6 @@ class WikidataSearch(IEntitySearch, IOntologySearch):
         class_params['srsearch'] = f"haswbstatement:P279 inlabel:{search_text}"
         return class_params
 
-    def local_search(self, default_entities: dict, search_text: str) -> List:
-        """ performs local partial text search across default entities"""
-        query_tokens = search_text.split(" ")
-        search_results = []
-        for key, entity in default_entities.items():
-            if all(list(map(lambda x: x.lower() in entity.label.lower(), query_tokens))):
-                search_results.append(entity)
-        return search_results
-
     def get_local_class_properties(self, id: str) -> OntClass:
         """Calls local class search API to fetch all class metadata using class ID"""
         if self.ont_class_ar is None:
@@ -63,28 +52,13 @@ class WikidataSearch(IEntitySearch, IOntologySearch):
 
     def find_class_by_name(self, search_text: str) -> List[SearchResult]:
         """
-        Uses Wikidata API and local default classes to search for classes using their name/text.
+        Uses Wikidata API to search for classes using their name/text.
         """
         request_params = self.get_class_search_params(search_text)
         api_data = requests.get(self.wikidata_url, request_params)
         search_results = api_data.json()['query']['search']
         payload_results = []
 
-        # search local classes
-        constructor = SETTINGS['ont_classes']['default']
-        default_classes = import_attr(constructor)
-        local_search_results = self.local_search(default_classes, search_text)
-
-        for entity in local_search_results:
-            item = SearchResult(
-                label=entity.label,
-                id=entity.id,
-                description=entity.description,
-                uri=entity.uri
-            )
-            payload_results.append(item)
-
-        # search wikidata
         for search_result in search_results:
             local_class_props = self.get_local_class_properties(search_result['title'])
             item = SearchResult(
@@ -97,27 +71,12 @@ class WikidataSearch(IEntitySearch, IOntologySearch):
         return payload_results
 
     def find_entity_by_name(self, search_text: str) -> List[SearchResult]:
-        """Uses Wikidata API and local default entities to search for entities using their name/text."""
+        """Uses Wikidata API to search for entities using their name/text."""
         request_params = self.get_entity_search_params(search_text)
         api_data = requests.get(self.wikidata_url, request_params)
         search_results = api_data.json()['query']['search']
         payload_results = []
 
-        # search local entities
-        constructor = SETTINGS['entity']['default']
-        default_entities = import_attr(constructor)
-        local_search_results = self.local_search(default_entities, search_text)
-
-        for entity in local_search_results:
-            item = SearchResult(
-                label=entity.label,
-                id=entity.id,
-                description=entity.description,
-                uri=entity.uri
-            )
-            payload_results.append(item)
-
-        # search wikidata
         for search_result in search_results:
             item = SearchResult(
                 label=nh3.clean(search_result['titlesnippet'], tags=set()),
@@ -129,27 +88,12 @@ class WikidataSearch(IEntitySearch, IOntologySearch):
         return payload_results
 
     def find_props_by_name(self, search_text: str) -> List[SearchResult]:
-        """Uses Wikidata API and local default properties to search for properties using their name/text."""
+        """Uses Wikidata API to search for properties using their name/text."""
         request_params = self.get_props_search_params(search_text)
         api_data = requests.get(self.wikidata_url, request_params)
         search_results = api_data.json()['query']['search']
         payload_results = []
 
-        # search local properties
-        constructor = SETTINGS['ont_props']['default']
-        default_properties = import_attr(constructor)
-        local_search_results = self.local_search(default_properties, search_text)
-
-        for entity in local_search_results:
-            item = SearchResult(
-                label=entity.label,
-                id=entity.id,
-                description=entity.description,
-                uri=entity.uri
-            )
-            payload_results.append(item)
-
-        # search wikidata
         for search_result in search_results:
             item = SearchResult(
                 label=nh3.clean(search_result['titlesnippet'], tags=set()),

--- a/sand/extensions/search/wikidata_search.py
+++ b/sand/extensions/search/wikidata_search.py
@@ -5,6 +5,8 @@ from sand.extension_interface.search import IEntitySearch, IOntologySearch
 from sand.models.entity import Entity
 from sand.models.ontology import OntClass, OntProperty, OntClassAR
 from sand.models.search import SearchResult
+from sm.misc.funcs import import_attr
+from sand.config import SETTINGS
 
 
 class WikidataSearch(IEntitySearch, IOntologySearch):
@@ -30,6 +32,15 @@ class WikidataSearch(IEntitySearch, IOntologySearch):
         class_params['srsearch'] = f"haswbstatement:P279 inlabel:{search_text}"
         return class_params
 
+    def local_search(self, default_entities: dict, search_text: str) -> List:
+        """ performs local partial text search across default entities"""
+        query_tokens = search_text.split(" ")
+        search_results = []
+        for key, entity in default_entities.items():
+            if all(list(map(lambda x: x.lower() in entity.label.lower(), query_tokens))):
+                search_results.append(entity)
+        return search_results
+
     def get_local_class_properties(self, id: str) -> OntClass:
         """Calls local class search API to fetch all class metadata using class ID"""
         if self.ont_class_ar is None:
@@ -52,13 +63,28 @@ class WikidataSearch(IEntitySearch, IOntologySearch):
 
     def find_class_by_name(self, search_text: str) -> List[SearchResult]:
         """
-        Uses Wikidata API to search for classes using their name/text.
-        Uses local ID based class search to fetch label and description data.
+        Uses Wikidata API and local default classes to search for classes using their name/text.
         """
         request_params = self.get_class_search_params(search_text)
         api_data = requests.get(self.wikidata_url, request_params)
         search_results = api_data.json()['query']['search']
         payload_results = []
+
+        # search local classes
+        constructor = SETTINGS['ont_classes']['default']
+        default_classes = import_attr(constructor)
+        local_search_results = self.local_search(default_classes, search_text)
+
+        for entity in local_search_results:
+            item = SearchResult(
+                label=entity.label,
+                id=entity.id,
+                description=entity.description,
+                uri=entity.uri
+            )
+            payload_results.append(item)
+
+        # search wikidata
         for search_result in search_results:
             local_class_props = self.get_local_class_properties(search_result['title'])
             item = SearchResult(
@@ -71,11 +97,27 @@ class WikidataSearch(IEntitySearch, IOntologySearch):
         return payload_results
 
     def find_entity_by_name(self, search_text: str) -> List[SearchResult]:
-        """Uses Wikidata API to search for entities using their name/text."""
+        """Uses Wikidata API and local default entities to search for entities using their name/text."""
         request_params = self.get_entity_search_params(search_text)
         api_data = requests.get(self.wikidata_url, request_params)
         search_results = api_data.json()['query']['search']
         payload_results = []
+
+        # search local entities
+        constructor = SETTINGS['entity']['default']
+        default_entities = import_attr(constructor)
+        local_search_results = self.local_search(default_entities, search_text)
+
+        for entity in local_search_results:
+            item = SearchResult(
+                label=entity.label,
+                id=entity.id,
+                description=entity.description,
+                uri=entity.uri
+            )
+            payload_results.append(item)
+
+        # search wikidata
         for search_result in search_results:
             item = SearchResult(
                 label=nh3.clean(search_result['titlesnippet'], tags=set()),
@@ -87,11 +129,27 @@ class WikidataSearch(IEntitySearch, IOntologySearch):
         return payload_results
 
     def find_props_by_name(self, search_text: str) -> List[SearchResult]:
-        """Uses Wikidata API to search for properties using their name/text."""
+        """Uses Wikidata API and local default properties to search for properties using their name/text."""
         request_params = self.get_props_search_params(search_text)
         api_data = requests.get(self.wikidata_url, request_params)
         search_results = api_data.json()['query']['search']
         payload_results = []
+
+        # search local properties
+        constructor = SETTINGS['ont_props']['default']
+        default_properties = import_attr(constructor)
+        local_search_results = self.local_search(default_properties, search_text)
+
+        for entity in local_search_results:
+            item = SearchResult(
+                label=entity.label,
+                id=entity.id,
+                description=entity.description,
+                uri=entity.uri
+            )
+            payload_results.append(item)
+
+        # search wikidata
         for search_result in search_results:
             item = SearchResult(
                 label=nh3.clean(search_result['titlesnippet'], tags=set()),

--- a/sand/extensions/search/wikidata_search.py
+++ b/sand/extensions/search/wikidata_search.py
@@ -5,6 +5,8 @@ from sand.extension_interface.search import IEntitySearch, IOntologySearch
 from sand.models.entity import Entity
 from sand.models.ontology import OntClass, OntProperty, OntClassAR
 from sand.models.search import SearchResult
+from sand.extensions.search.default_search import DefaultSearch
+from sand.extensions.search.aggregated_search import AggregatedSearch
 
 
 class WikidataSearch(IEntitySearch, IOntologySearch):
@@ -22,6 +24,13 @@ class WikidataSearch(IEntitySearch, IOntologySearch):
             "srprop": "snippet|titlesnippet"
         }
         self.ont_class_ar = None
+
+    def extended_wikidata_search(self) -> Union[IEntitySearch,IOntologySearch]:
+        """extended version of wikidata search by aggregating default search"""
+        search = AggregatedSearch()
+        search.add(DefaultSearch())
+        search.add(WikidataSearch())
+        return search
 
     def get_class_search_params(self, search_text: str) -> Dict:
         """Updates class search parameters for wikidata API"""

--- a/sand/extensions/wikidata.py
+++ b/sand/extensions/wikidata.py
@@ -24,7 +24,7 @@ WD_ONT_CLASSES = {
         uri=wdns.STATEMENT_URI,
         label=wdns.get_rel_uri(wdns.STATEMENT_URI),
         aliases=[],
-        description="",
+        description="Describes the claim of a statement and list references for this claim",
         parents=[],
     )
 }

--- a/sand/models/ontology.py
+++ b/sand/models/ontology.py
@@ -89,7 +89,7 @@ DEFAULT_ONT_PROPS = {
         label="rdfs:label",
         aliases=[],
         datatype="string",
-        description="",
+        description="Provides a human-readable version of a resource's name.",
         parents=[],
     )
 }


### PR DESCRIPTION
- Enabled local search for default classes, entities and properties for the Wikidata search.
   The default entities attribute path can be configured and updated in config.py 

- Updated descriptions for **_rdfs:label_** and **_wikibase:Statement_** default property and classes respectively.

**default drepr:nil entity**
<img width="1061" alt="Screenshot 2023-07-04 at 9 59 24 PM" src="https://github.com/usc-isi-i2/sand/assets/32421081/8ac871a6-0e8c-4240-8105-b54db740216f">

**default wikibase:Statement class**
<img width="1079" alt="Screenshot 2023-07-04 at 9 59 13 PM" src="https://github.com/usc-isi-i2/sand/assets/32421081/20260723-2877-42f4-b18f-23454273055b">

**default rdfs:label property**
<img width="1056" alt="Screenshot 2023-07-04 at 9 58 59 PM" src="https://github.com/usc-isi-i2/sand/assets/32421081/5ad2d327-0d88-4d47-92df-d63034604640">
